### PR TITLE
Revert "msm: camera_land_v2: Additional device specific change"

### DIFF
--- a/include/uapi/media/msm_camera.h
+++ b/include/uapi/media/msm_camera.h
@@ -2061,13 +2061,8 @@ struct msm_mctl_set_sdev_data {
 #define VIDIOC_MSM_AXI_BUF_CFG \
 	_IOWR('V', BASE_VIDIOC_PRIVATE + 22, void *)
 
-#ifdef CONFIG_LAND_CAMERA
-#define VIDIOC_MSM_AXI_RDI_COUNT_UPDATE \
-	_IOWR('V', BASE_VIDIOC_PRIVATE + 23, struct rdi_count_msg)
-#else
 #define VIDIOC_MSM_AXI_RDI_COUNT_UPDATE \
 	_IOWR('V', BASE_VIDIOC_PRIVATE + 23, void *)
-#endif
 
 #define VIDIOC_MSM_VFE_INIT \
 	_IO('V', BASE_VIDIOC_PRIVATE + 24)


### PR DESCRIPTION
This reverts commit 64fc835c120f65973a170fab457d290a1481dfac.

Useless commit, change was made by CAF upstream @ a446232b0a763c6c041864cd33e19596084cdcb5, it has no impact to camera.